### PR TITLE
fix(event): swap ScrnTimerCommand FadeOut/FadeIn

### DIFF
--- a/unplug/src/event/command.rs
+++ b/unplug/src/event/command.rs
@@ -821,8 +821,8 @@ expr_enum! {
         Unpause => -1,
         Show => 0,
         Hide => 1,
-        FadeIn => 2,
-        FadeOut => 3,
+        FadeOut => 2,
+        FadeIn => 3,
     }
 }
 


### PR DESCRIPTION
Closes #9. Per Kobazco's report and your confirmation, the discriminants 2 and 3 were swapped — in-game, value 2 should be FadeOut and 3 FadeIn.